### PR TITLE
Update dockerfile to apply patches

### DIFF
--- a/.konflux/dockerfiles/controller.Dockerfile
+++ b/.konflux/dockerfiles/controller.Dockerfile
@@ -5,8 +5,8 @@ FROM $GO_BUILDER AS builder
 
 WORKDIR /go/src/github.com/tektoncd/chains
 COPY upstream .
-COPY .konflux/patches patches/
-RUN set -e; for f in patches/*.patch; do echo ${f}; [[ -f ${f} ]] || continue; git apply ${f}; done
+COPY .konflux/patches/* upstream/patches/
+RUN set -e; cd upstream; for f in patches/*.patch; do echo "Applying patch: ${f}"; [[ -f ${f} ]] || continue; git apply ${f}; done; cd ../
 COPY head HEAD
 ENV GODEBUG="http2server=0"
 RUN go build -ldflags="-X 'knative.dev/pkg/changeset.rev=$(cat HEAD)'" -mod=vendor -tags disable_gcp -v -o /tmp/controller \


### PR DESCRIPTION
currently while applying patches we see
error related to go mod and module txt files
[build] patches/0002-go-1.22.patch
[build] error: go.mod: patch does not apply
[build] error: patch failed: vendor/modules.txt:201 [build] error: vendor/modules.txt: patch does not apply